### PR TITLE
Don't remove newlines at the end of a code line.

### DIFF
--- a/pygments_better_html/__init__.py
+++ b/pygments_better_html/__init__.py
@@ -140,7 +140,7 @@ class BetterHtmlFormatter(HtmlFormatter):
         )
         for lndata, cl in zip(lines, codelines):
             ln_b, ln, ln_a = lndata
-            cl = MANY_SPACES.sub(_sp_to_nbsp, cl.rstrip("\n"))
+            cl = MANY_SPACES.sub(_sp_to_nbsp, cl)
             if nocls:
                 yield 0, (
                     '<tr><td class="linenos linenodiv" style="background-color: #f0f0f0; padding-right: 10px">'


### PR DESCRIPTION
Hi, this PR is related to #1 . It seems the change is very straightforward however also feels like it's removing something that was put there on purpose.

Let me know if a different solution is necessary.

Finding out which lines are 'empty' is a bit hard as `cl` already contains the anchor tag for the line at the point it is wrapped.